### PR TITLE
Removed parameter 'div' from method 'setAndGetMultiplier(int, int, int)', 

### DIFF
--- a/src/main/java/smells/commentedoutcode/CommentedOutCode.java
+++ b/src/main/java/smells/commentedoutcode/CommentedOutCode.java
@@ -26,7 +26,7 @@ public class CommentedOutCode {
 				//		while (i < 10) {
 				//			result = result + i;
 		}
-		result = IncorrectOrderOfModifiers.setAndGetMultiplier(1, 2, 3);
+		result = IncorrectOrderOfModifiers.setAndGetMultiplier(1, 3);
 		
 		return result;
 	}
@@ -42,9 +42,10 @@ public class CommentedOutCode {
 				for (int i = 0; i < 10; i++) {
 						result = result + new Random().nextInt(2);
 				}
-				result = IncorrectOrderOfModifiers.setAndGetMultiplier(1, 2, 3);
+				result = IncorrectOrderOfModifiers.setAndGetMultiplier(1, 3);
 
 				return result;
 		}
 	
 }
+

--- a/src/main/java/smells/incorrectorderofmodifiers/IncorrectOrderOfModifiers.java
+++ b/src/main/java/smells/incorrectorderofmodifiers/IncorrectOrderOfModifiers.java
@@ -47,10 +47,10 @@ public class IncorrectOrderOfModifiers {
 	}
 
 		/**
-		 *
-		 * @return
-		 */
-		public static int setAndGetMultiplier(int mul, int div, int add) {
+ * 
+ * @return
+ */
+		public static int setAndGetMultiplier(int mul, int add) {
 				add = 1 + 1;
 				mul = add * add;
 
@@ -88,3 +88,4 @@ public class IncorrectOrderOfModifiers {
 		}
 
 }
+

--- a/src/main/java/smells/localvariableimmediatelyreturned/LocalVariableImmediatelyReturned.java
+++ b/src/main/java/smells/localvariableimmediatelyreturned/LocalVariableImmediatelyReturned.java
@@ -24,7 +24,7 @@ public class LocalVariableImmediatelyReturned extends MissingOverrideAnnotationS
 
 		protected int multiply2(int a, int b) {
 				int result = a * b;
-				result = IncorrectOrderOfModifiers.setAndGetMultiplier(1, 2, 3);
+				result = IncorrectOrderOfModifiers.setAndGetMultiplier(1, 3);
 				return result;
 
 				//		int i = 1;
@@ -36,7 +36,7 @@ public class LocalVariableImmediatelyReturned extends MissingOverrideAnnotationS
 
 		protected int calculateSomething2() {
 				int result = 0;
-				result = IncorrectOrderOfModifiers.setAndGetMultiplier(1, 2, 3);
+				result = IncorrectOrderOfModifiers.setAndGetMultiplier(1, 3);
 
 				//		int i = 1;
 				//		while (i < 10) {
@@ -63,3 +63,4 @@ public class LocalVariableImmediatelyReturned extends MissingOverrideAnnotationS
 		}
 
 }
+


### PR DESCRIPTION
Hi, I'm a refactoring bot. I found and fixed some code smells for you. 

 You can instruct me to perform changes on this pull request by creating line specific comments inside the 'Files changed' tab of this pull request. Use the english language to give me instructions and do not forget to tag me (using @) inside the comment to let me know that you are talking to me.